### PR TITLE
feat: add column quantity_in_stock table products in DB

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -202,6 +202,7 @@ class ProductController extends Controller
             'old_price' => 'nullable|numeric|min:0',
             'new_price' => 'required|numeric|min:0',
             'note' => 'nullable|string|max:255',
+            'quantity_in_stock' => 'nullable|integer|min:0',
         ]);
 
         if ($validator->fails()) {
@@ -239,6 +240,7 @@ class ProductController extends Controller
             'old_price' => $request->old_price,
             'new_price' => $request->new_price ?? $request->old_price,
             'note' => $request->note,
+            'quantity_in_stock' => $request->quantity_in_stock,
             'total_review' => 0,
             'average_review' => 0,
         ]);
@@ -325,6 +327,7 @@ class ProductController extends Controller
             'old_price' => 'sometimes|numeric|min:0',
             'new_price' => 'sometimes|numeric|min:0',
             'note' => 'nullable|string|max:255',
+            'quantity_in_stock' => 'nullable|integer|min:0',
         ]);
 
         if ($validator->fails()) {
@@ -364,6 +367,7 @@ class ProductController extends Controller
             'old_price' => $request->old_price ?? $product->old_price,
             'new_price' => $request->new_price ?? $product->new_price,
             'note' => $request->note ?? $product->note,
+            'quantity_in_stock' => $request->has('quantity_in_stock') ? $request->quantity_in_stock : $product->quantity_in_stock,
         ]);
 
         return response()->json([

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -26,6 +26,7 @@ class ProductResource extends JsonResource
             'image' => $this->formatImageUrls($this->image),
             'old_price' => $this->old_price,
             'new_price' => $this->new_price,
+            'quantity_in_stock' => $this->quantity_in_stock,
             'total_review' => $this->total_review,
             'average_review' => $this->average_review,
             'note' => $this->note,

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -35,6 +35,7 @@ class Product extends Model
         'old_price',
         'new_price',
         'note',
+        'quantity_in_stock',
         'rating_count',
         'rating_average',
     ];
@@ -62,6 +63,11 @@ class Product extends Model
                 'updated_at' => now(),
             ]);
         });
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'product_id';
     }
 
     public function category()

--- a/database/migrations/2025_12_26_220627_add_quantity_in_stock_to_products_table.php
+++ b/database/migrations/2025_12_26_220627_add_quantity_in_stock_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('quantity_in_stock')->nullable()->after('note');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('quantity_in_stock');
+        });
+    }
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Products now support inventory management through a new optional inventory quantity field. This field can be configured when creating products and updated at any time thereafter. The current inventory level is automatically included in all product API responses. The field accepts whole numbers with a minimum value of zero.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->